### PR TITLE
Fix typo in blossom_uploader

### DIFF
--- a/lib/upload/blossom_uploader.dart
+++ b/lib/upload/blossom_uploader.dart
@@ -14,7 +14,7 @@ import '../utils/hash_util.dart';
 import '../utils/string_util.dart';
 
 // This uploader not complete.
-class BolssomUploader {
+class BlossomUploader {
   static var dio = Dio();
 
   static Future<String?> upload(Nostr nostr, String endPoint, String filePath,
@@ -109,7 +109,7 @@ class BolssomUploader {
         return body["url"];
       }
     } catch (e) {
-      print("BolssomUploader.upload upload exception:");
+      print("BlossomUploader.upload upload exception:");
       print(e);
     }
 


### PR DESCRIPTION
Nostrmo and Plur currently use git submodules to point to [nostr_sdk](https://github.com/haorendashu/nostr_sdk) which contains code that theoretically could be used by any Nostr Flutter app. It also contains a typo.

So I forked it. The Verse fork is here, at `verse-pbc/nostr_sdk`, and I fixed that typo in this PR.

In order for Bryan's PR to build, we'd merge this, then point the git submodule inside of Plur to this repo since it contains the fixed spelling. Each developer will then have to run `git submodule sync` and `git submodule update` in Plur to pull the latest version of the code from this nostr_sdk repo. (Do you all know all of this already? Maybe I don't need to explain submodules to you -- and if not, sorry.)

I'm not a fan of git submodules and longer-term, I'd probably like to just include all of this nostr_sdk inside of the Plur repo. Or maybe there's a Flutter way to depend on nostr_sdk as a package. I'm open to other options, but I think it'd be great to not have to use git submodules.