### PR TITLE
add a function to check if an event id exists in the event list

### DIFF
--- a/lib/event_mem_box.dart
+++ b/lib/event_mem_box.dart
@@ -167,6 +167,10 @@ class EventMemBox implements FindEventInterface {
     addList(all);
   }
 
+  bool contains(String id) {
+    return _idMap[id] != null;
+  }
+
   bool isEmpty() {
     return _eventList.isEmpty;
   }


### PR DESCRIPTION
The "new notes added" toast is dependent on the number of new notes event. For some reason, after I did a lot of printing out, I noticed that the note event continued to be triggered and re-added to the newNotes list in the `_onNewEvent` function. This function is needed to check if that event id already exists in the notes list, so that the function can be exited.