### PR TITLE
It/update subscription

### DIFF
--- a/lib/event_kind.dart
+++ b/lib/event_kind.dart
@@ -59,6 +59,8 @@ class EventKind {
 
   static const int GROUP_CREATE_GROUP = 9007;
 
+   static const int GROUP_DELETE_GROUP = 9008;
+
   static const int GROUP_CREATE_INVITE = 9009;
 
   static const int GROUP_JOIN = 9021;

--- a/lib/nostr.dart
+++ b/lib/nostr.dart
@@ -151,9 +151,29 @@ class Nostr {
     _pool.addInitQuery(filters, onEvent, id: id, onComplete: onComplete);
   }
 
-  String subscribe(List<Map<String, dynamic>> filters, Function(Event) onEvent,
-      {String? id}) {
-    return _pool.subscribe(filters, onEvent, id: id);
+  bool tempRelayHasSubscription(String relayAddr) {
+    return _pool.tempRelayHasSubscription(relayAddr);
+  }
+
+  String subscribe(
+    List<Map<String, dynamic>> filters,
+    Function(Event) onEvent, {
+    String? id,
+    List<String>? tempRelays,
+    List<String>? targetRelays,
+    List<int> relayTypes = RelayType.ALL,
+    bool sendAfterAuth =
+        false, // if relay not connected, it will send after auth
+  }) {
+    return _pool.subscribe(
+      filters,
+      onEvent,
+      id: id,
+      tempRelays: tempRelays,
+      targetRelays: targetRelays,
+      relayTypes: relayTypes,
+      sendAfterAuth: sendAfterAuth,
+    );
   }
 
   void unsubscribe(String id) {
@@ -187,6 +207,7 @@ class Nostr {
     String? id,
     Function? onComplete,
     List<String>? tempRelays,
+    List<String>? targetRelays,
     List<int> relayTypes = RelayType.ALL,
     bool sendAfterAuth = false,
   }) {
@@ -196,6 +217,7 @@ class Nostr {
       id: id,
       onComplete: onComplete,
       tempRelays: tempRelays,
+      targetRelays: targetRelays,
       sendAfterAuth: sendAfterAuth,
     );
   }

--- a/lib/nostr.dart
+++ b/lib/nostr.dart
@@ -151,10 +151,17 @@ class Nostr {
     _pool.addInitQuery(filters, onEvent, id: id, onComplete: onComplete);
   }
 
+  /// Checks if a temporary relay has any active subscriptions
+  ///
+  /// [relayAddr] The relay address to check
+  /// Returns true if the relay has active subscriptions.
   bool tempRelayHasSubscription(String relayAddr) {
     return _pool.tempRelayHasSubscription(relayAddr);
   }
 
+  /// Subscribes to events matching the given filters.
+  ///
+  /// Returns the subscription ID that can be used to unsubscribe later
   String subscribe(
     List<Map<String, dynamic>> filters,
     Function(Event) onEvent, {
@@ -163,7 +170,7 @@ class Nostr {
     List<String>? targetRelays,
     List<int> relayTypes = RelayType.ALL,
     bool sendAfterAuth =
-        false, // if relay not connected, it will send after auth
+        false, // Defer subscription until after relay authentication is complete
   }) {
     return _pool.subscribe(
       filters,
@@ -260,9 +267,9 @@ class Nostr {
     _pool.reconnect();
   }
 
-  List<String> getExtralReadableRelays(
-      List<String> extralRelays, int maxRelayNum) {
-    return _pool.getExtralReadableRelays(extralRelays, maxRelayNum);
+  List<String> getExtraReadableRelays(
+      List<String> extraRelays, int maxRelayNum) {
+    return _pool.getExtraReadableRelays(extraRelays, maxRelayNum);
   }
 
   void removeTempRelay(String addr) {

--- a/lib/nostr.dart
+++ b/lib/nostr.dart
@@ -267,9 +267,9 @@ class Nostr {
     _pool.reconnect();
   }
 
-  List<String> getExtraReadableRelays(
+  List<String> getExtralReadableRelays(
       List<String> extraRelays, int maxRelayNum) {
-    return _pool.getExtraReadableRelays(extraRelays, maxRelayNum);
+    return _pool.getExtralReadableRelays(extraRelays, maxRelayNum);
   }
 
   void removeTempRelay(String addr) {

--- a/lib/nostr.dart
+++ b/lib/nostr.dart
@@ -18,7 +18,7 @@ class Nostr {
 
   NostrSigner nostrSigner;
 
-  String _publicKey;
+  final String _publicKey;
 
   Function(String, String)? onNotice;
 
@@ -161,7 +161,21 @@ class Nostr {
 
   /// Subscribes to events matching the given filters.
   ///
+  /// Parameters:
+  /// - [filters] The event filters to match against.
+  /// - [onEvent] Callback function when matching events are received.
+  /// - [id] Optional subscription identifier
+  /// - [tempRelays] Optional list of temporary relays used for one-off operations. These relays
+  ///   are created for specific queries and discarded after use, unlike the main relay pool.
+  /// - [targetRelays] Optional list of specific relays chosen from your configured relay set
+  ///   to handle this particular subscription.
+  /// - [relayTypes] Types of relays to use.
+  /// - [sendAfterAuth] Whether to wait for relay authentication before subscribing.
+  ///
   /// Returns the subscription ID that can be used to unsubscribe later
+  // TODO: Rename relay parameters globally for clarity:
+  //  - tempRelays
+  //  - targetRelays
   String subscribe(
     List<Map<String, dynamic>> filters,
     Function(Event) onEvent, {
@@ -169,8 +183,7 @@ class Nostr {
     List<String>? tempRelays,
     List<String>? targetRelays,
     List<int> relayTypes = RelayType.ALL,
-    bool sendAfterAuth =
-        false, // Defer subscription until after relay authentication is complete
+    bool sendAfterAuth = false,
   }) {
     return _pool.subscribe(
       filters,

--- a/lib/relay/relay.dart
+++ b/lib/relay/relay.dart
@@ -21,6 +21,9 @@ abstract class Relay {
 
   Function(Relay, List<dynamic>)? onMessage;
 
+  // subscriptions
+  final Map<String, Subscription> _subscriptions = {};
+
   // quries
   final Map<String, Subscription> _queries = {};
 
@@ -89,6 +92,28 @@ abstract class Relay {
         connect();
       });
     }
+  }
+
+  List<Subscription> getSubscriptions() {
+    return _subscriptions.values.toList();
+  }
+
+  void saveSubscription(Subscription subscription) {
+    _subscriptions[subscription.id] = subscription;
+  }
+
+  bool checkAndCompleteSubscription(String id) {
+    // all subscription should be close
+    var sub = _subscriptions.remove(id);
+    if (sub != null) {
+      send(["CLOSE", id]);
+      return true;
+    }
+    return false;
+  }
+
+  bool hasSubscription() {
+    return _subscriptions.isNotEmpty;
   }
 
   void saveQuery(Subscription subscription) {

--- a/lib/relay/relay.dart
+++ b/lib/relay/relay.dart
@@ -118,9 +118,7 @@ abstract class Relay {
   }
 
   /// Checks if this relay has any active subscriptions.
-  bool hasSubscription() {
-    return _subscriptions.isNotEmpty;
-  }
+  bool get hasSubscription => _subscriptions.isNotEmpty;
 
   void saveQuery(Subscription subscription) {
     _queries[subscription.id] = subscription;

--- a/lib/relay/relay.dart
+++ b/lib/relay/relay.dart
@@ -107,7 +107,7 @@ abstract class Relay {
   /// Attempts to close a subscription with the given ID.
   /// Sends a CLOSE message to the relay if subscription exists
   /// Returns true if subscription was found and closed, false otherwise
-  bool closeSubcriptionIfNeeded(String id) {
+  bool closeSubscriptionIfNeeded(String id) {
     // all subscription should be close
     var sub = _subscriptions.remove(id);
     if (sub != null) {

--- a/lib/relay/relay.dart
+++ b/lib/relay/relay.dart
@@ -94,15 +94,20 @@ abstract class Relay {
     }
   }
 
+  /// Returns a list of all active subscriptions for this relay connection.
   List<Subscription> getSubscriptions() {
     return _subscriptions.values.toList();
   }
 
+  /// Stores a new subscription in the relay's subscription map.
   void saveSubscription(Subscription subscription) {
     _subscriptions[subscription.id] = subscription;
   }
 
-  bool checkAndCompleteSubscription(String id) {
+  /// Attempts to close a subscription with the given ID.
+  /// Sends a CLOSE message to the relay if subscription exists
+  /// Returns true if subscription was found and closed, false otherwise
+  bool closeSubcriptionIfNeeded(String id) {
     // all subscription should be close
     var sub = _subscriptions.remove(id);
     if (sub != null) {
@@ -112,6 +117,7 @@ abstract class Relay {
     return false;
   }
 
+  /// Checks if this relay has any active subscriptions.
   bool hasSubscription() {
     return _subscriptions.isNotEmpty;
   }

--- a/lib/relay/relay.dart
+++ b/lib/relay/relay.dart
@@ -95,9 +95,7 @@ abstract class Relay {
   }
 
   /// Returns a list of all active subscriptions for this relay connection.
-  List<Subscription> getSubscriptions() {
-    return _subscriptions.values.toList();
-  }
+  List<Subscription> get subscriptions => _subscriptions.values.toList();
 
   /// Stores a new subscription in the relay's subscription map.
   void saveSubscription(Subscription subscription) {

--- a/lib/relay/relay_pool.dart
+++ b/lib/relay/relay_pool.dart
@@ -640,7 +640,7 @@ class RelayPool {
     return tempRelay;
   }
 
-  List<String> getExtraReadableRelays(
+  List<String> getExtralReadableRelays(
       List<String> extraRelays, int maxRelayNum) {
     List<String> list = [];
 

--- a/lib/relay/relay_pool.dart
+++ b/lib/relay/relay_pool.dart
@@ -93,8 +93,8 @@ class RelayPool {
 
   List<Relay> activeRelays() {
     List<Relay> list = [];
-    var it = _relays.values;
-    for (var relay in it) {
+    final it = _relays.values;
+    for (final relay in it) {
       if (relay.relayStatus.connected == ClientConneccted.CONNECTED) {
         list.add(relay);
       }
@@ -291,8 +291,8 @@ class RelayPool {
             relay.pendingAuthedMessages.clear();
 
             // Resubscribe to all active subscriptions after authentication
-            if (relay.hasSubscription()) {
-              final subs = relay.getSubscriptions();
+            if (relay.hasSubscription) {
+              final subs = relay.subscriptions;
               // Resend each subscription request to the relay
               for (var subscription in subs) {
                 relay.send(subscription.toJson());
@@ -438,7 +438,7 @@ class RelayPool {
   /// Returns true if the relay exists and has subscriptions
   bool tempRelayHasSubscription(String relayAddr) {
     // Return subscription status if relay exists, otherwise false
-    return _tempRelays[relayAddr]?.hasSubscription() ?? false;
+    return _tempRelays[relayAddr]?.hasSubscription ?? false;
   }
 
   /// Unsubscribes from a subscription or query by its ID.
@@ -452,7 +452,7 @@ class RelayPool {
         ..._tempRelays.values,
         ..._cacheRelays.values
       ]) {
-        relay.closeSubcriptionIfNeeded(id);
+        relay.closeSubscriptionIfNeeded(id);
       }
     } else {
       // Complete query across all relay types
@@ -645,10 +645,10 @@ class RelayPool {
     List<String> list = [];
 
     int sameNum = 0;
-    for (var extraRelay in extraRelays) {
-      extraRelay = RelayAddrUtil.handle(extraRelay);
+    for (final extraRelay in extraRelays) {
+      final relayAddr = RelayAddrUtil.handle(extraRelay);
 
-      var relay = _relays[extraRelay];
+      final relay = _relays[relayAddr];
       if (relay == null || !relay.relayStatus.readAccess) {
         // not contains or can't readable
         list.add(extraRelay);
@@ -657,7 +657,7 @@ class RelayPool {
       }
     }
 
-    var needExtraNum = maxRelayNum - sameNum;
+    final needExtraNum = maxRelayNum - sameNum;
     if (needExtraNum <= 0) {
       return [];
     }

--- a/lib/relay/relay_pool.dart
+++ b/lib/relay/relay_pool.dart
@@ -1,5 +1,6 @@
-import 'dart:convert';
 import 'dart:developer';
+
+import 'package:nostr_sdk/utils/relay_addr_util.dart';
 
 import '../event.dart';
 import '../event_kind.dart';
@@ -10,8 +11,6 @@ import '../utils/string_util.dart';
 import 'client_connected.dart';
 import 'event_filter.dart';
 import 'relay.dart';
-import 'relay_base.dart';
-import 'relay_isolate.dart';
 import 'relay_type.dart';
 
 class RelayPool {
@@ -198,13 +197,6 @@ class RelayPool {
             return;
           }
         }
-        // if (filterProvider.checkBlock(event.pubkey)) {
-        //   return;
-        // }
-        // // check dirtyword
-        // if (filterProvider.checkDirtyword(event.content)) {
-        //   return;
-        // }
 
         if (relay is RelayLocal ||
             relay.relayStatus.relayType == RelayType.CACHE) {
@@ -297,6 +289,14 @@ class RelayPool {
               relay.send(message);
             }
             relay.pendingAuthedMessages.clear();
+
+            // send subcription, but some subscrpition will send twice
+            if (relay.hasSubscription()) {
+              var subs = relay.getSubscriptions();
+              for (var subscription in subs) {
+                relay.send(subscription.toJson());
+              }
+            }
           });
         }
       }
@@ -320,25 +320,146 @@ class RelayPool {
   /// like: subscribe the newest event、notice.
   /// subscribe info will hold in reply pool and close in reply pool.
   /// subscribe can be subscribe when new relay put into pool.
-  String subscribe(List<Map<String, dynamic>> filters, Function(Event) onEvent,
-      {String? id}) {
+  String subscribe(
+    List<Map<String, dynamic>> filters,
+    Function(Event) onEvent, {
+    String? id,
+    List<String>? tempRelays,
+    List<String>? targetRelays,
+    List<int> relayTypes = RelayType.ALL,
+    bool sendAfterAuth =
+        false, // if relay not connected, it will send after auth
+  }) {
     if (filters.isEmpty) {
       throw ArgumentError("No filters given", "filters");
     }
 
+    handleAddrList(tempRelays);
+    handleAddrList(targetRelays);
+
     final Subscription subscription = Subscription(filters, onEvent, id);
     _subscriptions[subscription.id] = subscription;
-    send(subscription.toJson());
+    // send(subscription.toJson());
+
+    // tempRelay, only query those relay which has bean provide
+    if (tempRelays != null &&
+        tempRelays.isNotEmpty &&
+        relayTypes.contains(RelayType.TEMP)) {
+      for (var tempRelayAddr in tempRelays) {
+        // check if normal relays has this temp relay, try to get relay from normal relays
+        Relay? relay = _relays[tempRelayAddr];
+        relay ??= checkAndGenTempRelay(tempRelayAddr);
+
+        relayDoSubscribe(relay, subscription, sendAfterAuth,
+            runBeforeConnected: true);
+      }
+    }
+
+    // normal relay, usually will query all the normal relays, but if targetRelays has provide, it only query from the provided querys.
+    if (relayTypes.contains(RelayType.NORMAL)) {
+      for (var entry in _relays.entries) {
+        var relayAddr = entry.key;
+        var relay = entry.value;
+
+        if (targetRelays != null) {
+          if (!targetRelays.contains(relayAddr)) {
+            continue;
+          }
+        }
+
+        relayDoSubscribe(relay, subscription, sendAfterAuth);
+      }
+    }
+
+    // cache relay
+    if (relayTypes.contains(RelayType.CACHE)) {
+      for (var relay in _cacheRelays.values) {
+        relayDoSubscribe(relay, subscription, sendAfterAuth);
+      }
+    }
+
+    // local relay
+    if (relayTypes.contains(RelayType.LOCAL) && relayLocal != null) {
+      relayDoSubscribe(relayLocal!, subscription, sendAfterAuth);
+    }
+
     return subscription.id;
+  }
+
+  bool relayDoSubscribe(
+      Relay relay, Subscription subscription, bool sendAfterAuth,
+      {bool runBeforeConnected = false}) {
+    if ((!runBeforeConnected &&
+            relay.relayStatus.connected != ClientConneccted.CONNECTED) ||
+        !relay.relayStatus.readAccess) {
+      return false;
+    }
+
+    relay.relayStatus.onQuery();
+
+    try {
+      relay.saveSubscription(subscription);
+
+      var message = subscription.toJson();
+      if (sendAfterAuth && !relay.relayStatus.authed) {
+        relay.pendingAuthedMessages.add(message);
+        return true;
+      } else {
+        if (relay.relayStatus.connected == ClientConneccted.CONNECTED) {
+          return relay.send(message);
+        } else {
+          relay.pendingMessages.add(message);
+          return true;
+        }
+      }
+    } catch (err) {
+      log(err.toString());
+      relay.relayStatus.onError();
+    }
+
+    return false;
+  }
+
+  bool tempRelayHasSubscription(String relayAddr) {
+    var relay = _tempRelays[relayAddr];
+    if (relay != null) {
+      return relay.hasSubscription();
+    }
+
+    return false;
   }
 
   void unsubscribe(String id) {
     final subscription = _subscriptions.remove(id);
     if (subscription != null) {
-      send(["CLOSE", subscription.id]);
+      // check query and send close
+      var it = _relays.values;
+      for (var relay in it) {
+        relay.checkAndCompleteSubscription(id);
+      }
+
+      it = _tempRelays.values;
+      for (var relay in it) {
+        relay.checkAndCompleteSubscription(id);
+      }
+
+      it = _cacheRelays.values;
+      for (var relay in it) {
+        relay.checkAndCompleteSubscription(id);
+      }
     } else {
       // check query and send close
       var it = _relays.values;
+      for (var relay in it) {
+        relay.checkAndCompleteQuery(id);
+      }
+
+      it = _tempRelays.values;
+      for (var relay in it) {
+        relay.checkAndCompleteQuery(id);
+      }
+
+      it = _cacheRelays.values;
       for (var relay in it) {
         relay.checkAndCompleteQuery(id);
       }
@@ -370,6 +491,16 @@ class RelayPool {
     return id;
   }
 
+  void handleAddrList(List<String>? addrList) {
+    if (addrList != null) {
+      var length = addrList.length;
+      for (var i = 0; i < length; i++) {
+        var relayAddr = addrList[i];
+        addrList[i] = RelayAddrUtil.handle(relayAddr);
+      }
+    }
+  }
+
   /// query should be a one time filter search.
   /// like: query metadata, query old event.
   /// query info will hold in relay and close in relay when EOSE message be received.
@@ -389,6 +520,10 @@ class RelayPool {
     if (filters.isEmpty) {
       throw ArgumentError("No filters given", "filters");
     }
+
+    handleAddrList(tempRelays);
+    handleAddrList(targetRelays);
+
     Subscription subscription = Subscription(filters, onEvent, id);
     if (onComplete != null) {
       _queryCompleteCallbacks[subscription.id] = onComplete;
@@ -510,6 +645,8 @@ class RelayPool {
 
     int sameNum = 0;
     for (var extralRelay in extralRelays) {
+      extralRelay = RelayAddrUtil.handle(extralRelay);
+
       var relay = _relays[extralRelay];
       if (relay == null || !relay.relayStatus.readAccess) {
         // not contains or can't readable

--- a/lib/relay/relay_pool.dart
+++ b/lib/relay/relay_pool.dart
@@ -292,7 +292,7 @@ class RelayPool {
 
             // Resubscribe to all active subscriptions after authentication
             if (relay.hasSubscription()) {
-              var subs = relay.getSubscriptions();
+              final subs = relay.getSubscriptions();
               // Resend each subscription request to the relay
               for (var subscription in subs) {
                 relay.send(subscription.toJson());


### PR DESCRIPTION
This PR adds the group delete event, so that we can subscribe to deletion events sent from outside Plur.

It also updates the `subscribe` functionality. We needed to include targeted relays to subscribe to. That was not being done initially. I copied this functionality from the forked [nostr_sdk](https://github.com/haorendashu/nostr_sdk) because it was implemented recently and it works, and I didn't have to try to figure out how to make it work.