### PR TITLE
Use NIP-44 encryption in NIP-46 remote requests

### DIFF
--- a/lib/nip46/nostr_remote_request.dart
+++ b/lib/nip46/nostr_remote_request.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 
-import 'package:sentry/sentry.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 
 import '../signer/nostr_signer.dart';
 import '../utils/string_util.dart';

--- a/lib/nip46/nostr_remote_request.dart
+++ b/lib/nip46/nostr_remote_request.dart
@@ -19,13 +19,13 @@ class NostrRemoteRequest {
     jsonMap["params"] = params;
 
     var jsonStr = jsonEncode(jsonMap);
-    return await signer.encrypt(pubkey, jsonStr);
+    return await signer.nip44Encrypt(pubkey, jsonStr);
   }
 
   static Future<NostrRemoteRequest?> decrypt(
       String ciphertext, NostrSigner signer, String pubkey) async {
     try {
-      var plaintext = await signer.decrypt(pubkey, ciphertext);
+      var plaintext = await signer.nip44Decrypt(pubkey, ciphertext);
       if (StringUtil.isNotBlank(plaintext)) {
         // print(plaintext);
         var jsonMap = jsonDecode(plaintext!);

--- a/lib/nip46/nostr_remote_request.dart
+++ b/lib/nip46/nostr_remote_request.dart
@@ -1,54 +1,83 @@
 import 'dart:convert';
 
+import 'package:sentry/sentry.dart';
+
 import '../signer/nostr_signer.dart';
 import '../utils/string_util.dart';
 
+/// A class representing a remote request in the Nostr protocol.
 class NostrRemoteRequest {
+  /// The unique identifier for the request.
   String id;
 
+  /// The method name of the request.
   String method;
 
+  /// The parameters for the request.
   List<String> params;
 
+  /// Creates a new NostrRemoteRequest with the given method and parameters.
+  ///
+  /// A unique ID is generated for the request.
   NostrRemoteRequest(this.method, this.params) : id = StringUtil.rndNameStr(12);
 
+  /// Encrypts the request using the given [signer] and [pubkey].
+  ///
+  /// The request is converted to a JSON string and then encrypted.
+  /// Returns the encrypted string or null if the encryption fails.
   Future<String?> encrypt(NostrSigner signer, String pubkey) async {
+    // Create a JSON map with the request details.
     Map<String, dynamic> jsonMap = {};
     jsonMap["id"] = id;
     jsonMap["method"] = method;
     jsonMap["params"] = params;
 
+    // Convert the JSON map to a string.
     var jsonStr = jsonEncode(jsonMap);
+
+    // Encrypt the JSON string using the signer.
     return await signer.nip44Encrypt(pubkey, jsonStr);
   }
 
+  /// Decrypts the given [ciphertext] using the [signer] and [pubkey].
+  ///
+  /// If the decryption is successful, a NostrRemoteRequest object is created
+  /// from the decrypted data and returned. Returns null if the decryption
+  /// fails.
   static Future<NostrRemoteRequest?> decrypt(
       String ciphertext, NostrSigner signer, String pubkey) async {
     try {
+      // Decrypt the ciphertext using the signer.
       var plaintext = await signer.nip44Decrypt(pubkey, ciphertext);
+
+      // Check if the plaintext is not blank.
       if (StringUtil.isNotBlank(plaintext)) {
-        // print(plaintext);
+        // Decode the JSON string to a map.
         var jsonMap = jsonDecode(plaintext!);
 
+        // Extract the request details from the JSON map.
         var id = jsonMap["id"];
         var method = jsonMap["method"];
-        var _params = jsonMap["params"];
-        List<String> params = [];
-        if (_params != null && _params is List) {
-          for (var param in _params) {
-            params.add(param);
+        var params = jsonMap["params"];
+
+        // Create a list for the request parameters.
+        List<String> requestParams = [];
+        if (params != null && params is List) {
+          for (var param in params) {
+            requestParams.add(param);
           }
         }
 
+        // Check if the ID and method are valid.
         if (id != null && id is String && method != null && method is String) {
-          var request = NostrRemoteRequest(method, params);
+          // Create a new NostrRemoteRequest object with the decrypted details.
+          var request = NostrRemoteRequest(method, requestParams);
           request.id = id;
           return request;
         }
       }
-    } catch (e) {
-      print("NostrRemoteRequest decrypt error");
-      print(e);
+    } catch (exception, stackTrace) {
+      await Sentry.captureException(exception, stackTrace: stackTrace);
     }
 
     return null;

--- a/lib/nip46/nostr_remote_response.dart
+++ b/lib/nip46/nostr_remote_response.dart
@@ -3,26 +3,43 @@ import 'dart:convert';
 import '../signer/nostr_signer.dart';
 import '../utils/string_util.dart';
 
+/// A class representing a remote response in the Nostr protocol.
 class NostrRemoteResponse {
+  /// The unique identifier for the response.
   String id;
 
+  /// The result of the response.
   String result;
 
+  /// The error message, if any.
   String? error;
 
+  /// Creates a new NostrRemoteResponse with the given id, result, and optional
+  /// error.
   NostrRemoteResponse(this.id, this.result, {this.error});
 
+  /// Decrypts the given [ciphertext] using the [signer] and [pubkey].
+  ///
+  /// If the decryption is successful, a NostrRemoteResponse object is created
+  /// from the decrypted data and returned. Returns null if the decryption
+  /// fails.
   static Future<NostrRemoteResponse?> decrypt(
       String ciphertext, NostrSigner signer, String pubkey) async {
+    // Decrypt the ciphertext using the signer.
     var plaintext = await signer.nip44Decrypt(pubkey, ciphertext);
+
+    // Check if the plaintext is not blank.
     if (StringUtil.isNotBlank(plaintext)) {
-      // print("plaintext $plaintext");
+      // Decode the JSON string to a map.
       var jsonMap = jsonDecode(plaintext!);
 
+      // Extract the response details from the JSON map.
       var id = jsonMap["id"];
       var result = jsonMap["result"];
 
+      // Check if the ID and result are valid.
       if (id != null && id is String && result != null && result is String) {
+        // Create a new NostrRemoteResponse object with the decrypted details.
         return NostrRemoteResponse(id, result, error: jsonMap["error"]);
       }
     }
@@ -30,7 +47,12 @@ class NostrRemoteResponse {
     return null;
   }
 
+  /// Encrypts the response using the given [signer] and [pubkey].
+  ///
+  /// The response is converted to a JSON string and then encrypted.
+  /// Returns the encrypted string or null if the encryption fails.
   Future<String?> encrypt(NostrSigner signer, String pubkey) async {
+    // Create a JSON map with the response details.
     Map<String, dynamic> jsonMap = {};
     jsonMap["id"] = id;
     jsonMap["result"] = result;
@@ -38,7 +60,10 @@ class NostrRemoteResponse {
       jsonMap["error"] = error;
     }
 
+    // Convert the JSON map to a string.
     var jsonStr = jsonEncode(jsonMap);
+
+    // Encrypt the JSON string using the signer.
     return await signer.nip44Encrypt(pubkey, jsonStr);
   }
 

--- a/lib/nip46/nostr_remote_response.dart
+++ b/lib/nip46/nostr_remote_response.dart
@@ -14,7 +14,7 @@ class NostrRemoteResponse {
 
   static Future<NostrRemoteResponse?> decrypt(
       String ciphertext, NostrSigner signer, String pubkey) async {
-    var plaintext = await signer.decrypt(pubkey, ciphertext);
+    var plaintext = await signer.nip44Decrypt(pubkey, ciphertext);
     if (StringUtil.isNotBlank(plaintext)) {
       // print("plaintext $plaintext");
       var jsonMap = jsonDecode(plaintext!);
@@ -39,7 +39,7 @@ class NostrRemoteResponse {
     }
 
     var jsonStr = jsonEncode(jsonMap);
-    return await signer.encrypt(pubkey, jsonStr);
+    return await signer.nip44Encrypt(pubkey, jsonStr);
   }
 
   @override

--- a/lib/nip46/nostr_remote_signer_info.dart
+++ b/lib/nip46/nostr_remote_signer_info.dart
@@ -4,18 +4,26 @@ import '../utils/string_util.dart';
 
 /// This client is designed for nostr client.
 class NostrRemoteSignerInfo {
+  /// The public key of the remote signer.
   String remoteSignerPubkey;
 
+  /// The list of relay URLs.
   List<String> relays;
 
+  /// An optional secret, can be null.
   String? optionalSecret;
 
-  // Client signer nsec, sometime need to save all info in one place, so nsec should save as a par here.
+  /// The client's signer nsec, sometimes needed to save all info in one place.
+  /// Can be null.
   String? nsec;
 
-  // User Pubkey, sometime need to save all info in one place, so nsec should save as a par here.
+  /// The user's public key, sometimes needed to save all info in one place.
+  /// Can be null.
   String? userPubkey;
 
+  /// Constructs a [NostrRemoteSignerInfo] with the required remote signer
+  /// public key and list of relay URLs.
+  /// Optional parameters include the secret, nsec, and user public key.
   NostrRemoteSignerInfo({
     required this.remoteSignerPubkey,
     required this.relays,
@@ -45,17 +53,16 @@ class NostrRemoteSignerInfo {
     return uri.toString();
   }
 
-  static bool isBunkerUrl(String? bunkerUrlText) {
-    if (bunkerUrlText != null) {
-      return bunkerUrlText.startsWith("bunker://");
-    }
-
-    return false;
+  /// Checks if the given [url] is a valid bunker URL.
+  static bool isBunkerUrl(String? url) {
+    if (url == null) return false;
+    return url.startsWith("bunker://");
   }
 
-  static NostrRemoteSignerInfo? parseBunkerUrl(String bunkerUrlText,
-      {String? nsec}) {
-    var uri = Uri.parse(bunkerUrlText);
+  /// Parses a bunker URL and returns a [NostrRemoteSignerInfo] object if valid.
+  /// If nsec is not provided, it will be generated.
+  static NostrRemoteSignerInfo? parseBunkerUrl(String url, {String? nsec}) {
+    var uri = Uri.parse(url);
 
     var pars = uri.queryParametersAll;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   pretty_dio_logger: ^1.3.1
   mime: ^1.0.5
   android_content_provider: ^0.4.2
+  sentry_flutter: ^8.13.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Updates the NIP-46 remote signing protocol so that it uses NIP-44 encryption.

- [x] Integrate commit [ec859fba9924b3236d08f293d79f4a4ec4f1cad7](https://github.com/haorendashu/nostr_sdk/commit/ec859fba9924b3236d08f293d79f4a4ec4f1cad7)
- [x] Use Sentry for handling exceptions
- [x] Run diagnostics tool in modified files
- [x] Run format tool in modified files
- [x] Add comments where appropriate